### PR TITLE
Clear shared pollution to avoid flaky tests

### DIFF
--- a/core/src/test/java/com/pholser/junit/quickcheck/ComponentizedGeneratorsIsolateConfigurationFromComponentsTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/ComponentizedGeneratorsIsolateConfigurationFromComponentsTest.java
@@ -43,6 +43,7 @@ public class ComponentizedGeneratorsIsolateConfigurationFromComponentsTest {
     @Test public void boxOfFoo() throws Exception {
         assertThat(testResult(BoxOfFoo.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), BoxOfFoo.iterations);
+        BoxOfFoo.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/EnumPropertyParameterTypesTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/EnumPropertyParameterTypesTest.java
@@ -48,6 +48,7 @@ public class EnumPropertyParameterTypesTest {
     @Test public void usesRegularTrialCount() throws Exception {
         assertThat(testResult(EnumTester.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), EnumTester.iterations);
+        EnumTester.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -65,6 +66,7 @@ public class EnumPropertyParameterTypesTest {
             defaultPropertyTrialCount(),
             EnumWithConstraint.values.size());
         assertThat(EnumWithConstraint.values, not(hasItem(E3)));
+        EnumWithConstraint.values.clear();
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/ExhaustingAGivenSetButIncludingAnotherTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/ExhaustingAGivenSetButIncludingAnotherTest.java
@@ -98,6 +98,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             singletonList(false),
             WrapperBooleans.values.subList(0, 1));
+        WrapperBooleans.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -143,6 +144,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(Byte.valueOf("14"), Byte.valueOf("-15"))),
             new HashSet<>(WrapperBytes.values.subList(0, 2)));
+        WrapperBytes.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -166,6 +168,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList('Z', 'z')),
             new HashSet<>(PrimitiveChars.values.subList(0, 2)));
+        PrimitiveChars.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -187,6 +190,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList('@', '#')),
             new HashSet<>(WrapperChars.values.subList(0, 2)));
+        WrapperChars.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -210,6 +214,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(3.2, -4D)),
             new HashSet<>(PrimitiveDoubles.values.subList(0, 2)));
+        PrimitiveDoubles.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -233,6 +238,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(2.7, -3.14)),
             new HashSet<>(WrapperDoubles.values.subList(0, 2)));
+        WrapperDoubles.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -256,6 +262,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(3.3F, -5F)),
             new HashSet<>(PrimitiveFloats.values.subList(0, 2)));
+        PrimitiveFloats.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -279,6 +286,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(1.7F, -4.14F)),
             new HashSet<>(WrapperFloats.values.subList(0, 2)));
+        WrapperFloats.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -302,6 +310,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(1, 2, 3)),
             new HashSet<>(PrimitiveIntegers.values.subList(0, 3)));
+        PrimitiveIntegers.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -325,6 +334,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(4, 5)),
             new HashSet<>(WrapperIntegers.values.subList(0, 2)));
+        WrapperIntegers.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -348,6 +358,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(-6L, -7L, -8L)),
             new HashSet<>(PrimitiveLongs.values.subList(0, 3)));
+        PrimitiveLongs.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -371,6 +382,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(10L, 11L, 12L)),
             new HashSet<>(WrapperLongs.values.subList(0, 3)));
+        WrapperLongs.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -394,6 +406,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(Short.valueOf("9"), Short.valueOf("8"))),
             new HashSet<>(PrimitiveShorts.values.subList(0, 2)));
+        PrimitiveShorts.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -417,6 +430,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(Short.valueOf("-13"), Short.valueOf("-14"))),
             new HashSet<>(WrapperShorts.values.subList(0, 2)));
+        WrapperShorts.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -440,6 +454,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList("some", "values")),
             new HashSet<>(Strings.values.subList(0, 2)));
+        Strings.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -546,6 +561,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
                     FavorValueOf.Target.valueOf("a"),
                     FavorValueOf.Target.valueOf("b"))),
             new HashSet<>(FavorValueOf.values.subList(0, 2)));
+        FavorValueOf.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/ExhaustingAGivenSetTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/ExhaustingAGivenSetTest.java
@@ -58,6 +58,7 @@ public class ExhaustingAGivenSetTest {
         assertThat(testResult(PrimitiveBooleans.class), isSuccessful());
         assertEquals(1, PrimitiveBooleans.iterations);
         assertEquals(singleton(true), PrimitiveBooleans.testCases);
+        PrimitiveBooleans.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -77,6 +78,7 @@ public class ExhaustingAGivenSetTest {
         assertThat(testResult(WrapperBooleans.class), isSuccessful());
         assertEquals(1, WrapperBooleans.iterations);
         assertEquals(singleton(false), WrapperBooleans.testCases);
+        WrapperBooleans.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -98,6 +100,7 @@ public class ExhaustingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(true, false)),
             UnmarkedBooleans.testCases);
+        UnmarkedBooleans.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -119,6 +122,7 @@ public class ExhaustingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(Byte.valueOf("12"), Byte.valueOf("-13"))),
             PrimitiveBytes.testCases);
+        PrimitiveBytes.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -140,6 +144,7 @@ public class ExhaustingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(Byte.valueOf("14"), Byte.valueOf("-15"))),
             WrapperBytes.testCases);
+        WrapperBytes.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -161,6 +166,7 @@ public class ExhaustingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList('Z', 'z')),
             PrimitiveChars.testCases);
+        PrimitiveChars.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -228,6 +234,7 @@ public class ExhaustingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(2.7, -3.14)),
             WrapperDoubles.testCases);
+        WrapperDoubles.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -340,6 +347,7 @@ public class ExhaustingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(-6L, -7L, -8L)),
             PrimitiveLongs.testCases);
+        PrimitiveLongs.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -361,6 +369,7 @@ public class ExhaustingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(10L, 11L, 12L)),
             WrapperLongs.testCases);
+        WrapperLongs.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -475,6 +484,7 @@ public class ExhaustingAGivenSetTest {
         assertEquals(
             EnumSet.allOf(RoundingMode.class),
             EnumsUnmarked.testCases);
+        EnumsUnmarked.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -653,6 +663,9 @@ public class ExhaustingAGivenSetTest {
             asList('r', 'r', 'r', 'y', 'y', 'y'),
             ManyParameters.secondTestCases
         );
+        ManyParameters.iterations = 0;
+        ManyParameters.firstTestCases.clear();
+        ManyParameters.secondTestCases.clear();
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/LambdaPropertyParameterTypesTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/LambdaPropertyParameterTypesTest.java
@@ -44,6 +44,7 @@ public class LambdaPropertyParameterTypesTest {
     @Test public void unboxingAFoo() throws Exception {
         assertThat(testResult(UnboxingAFoo.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), UnboxingAFoo.iterations);
+        UnboxingAFoo.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/PropertyExhaustiveSampleSizeTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/PropertyExhaustiveSampleSizeTest.java
@@ -66,6 +66,7 @@ public class PropertyExhaustiveSampleSizeTest {
             testResult(ForSpecifiedNumberOfValues.class),
             isSuccessful());
         assertEquals(5, ForSpecifiedNumberOfValues.iterations);
+        ForSpecifiedNumberOfValues.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -91,6 +92,8 @@ public class PropertyExhaustiveSampleSizeTest {
         assertEquals(foos.get(1), foos.get(3));
         assertEquals(foos.get(2), foos.get(6));
         assertEquals(foos.get(5), foos.get(7));
+        ForValuesOfMultipleParameters.iterations = 0;
+        ForValuesOfMultipleParameters.foos.clear();
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/SamplingButAlsoIncludingAGivenSetTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/SamplingButAlsoIncludingAGivenSetTest.java
@@ -99,6 +99,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(true, false)),
             new HashSet<>(WrapperBooleans.values));
+        WrapperBooleans.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -144,6 +145,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList((byte) 14, (byte) -15)),
             new HashSet<>(WrapperBytes.values.subList(0, 2)));
+        WrapperBytes.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -258,6 +260,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(3.3F, -5F)),
             new HashSet<>(PrimitiveFloats.values.subList(0, 2)));
+        PrimitiveFloats.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -280,6 +283,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(1.7F, -4.14F)),
             new HashSet<>(WrapperFloats.values.subList(0, 2)));
+        WrapperFloats.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -304,6 +308,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(1, 2, 3)),
             new HashSet<>(PrimitiveIntegers.values.subList(0, 3)));
+        PrimitiveIntegers.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -326,6 +331,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(4, 5)),
             new HashSet<>(WrapperIntegers.values.subList(0, 2)));
+        WrapperIntegers.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -348,6 +354,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(-6L, -7L, -8L)),
             new HashSet<>(PrimitiveLongs.values.subList(0, 3)));
+        PrimitiveLongs.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -370,6 +377,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(10L, 11L, 12L)),
             new HashSet<>(WrapperLongs.values.subList(0, 3)));
+        WrapperLongs.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -392,6 +400,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(Short.valueOf("9"), Short.valueOf("8"))),
             new HashSet<>(PrimitiveShorts.values.subList(0, 2)));
+        PrimitiveShorts.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -414,6 +423,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(Short.valueOf("-13"), Short.valueOf("-14"))),
             new HashSet<>(WrapperShorts.values.subList(0, 2)));
+        WrapperShorts.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -436,6 +446,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList("some", "values")),
             new HashSet<>(Strings.values.subList(0, 2)));
+        Strings.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/SamplingOnlyFromAGivenSetTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/SamplingOnlyFromAGivenSetTest.java
@@ -60,6 +60,7 @@ public class SamplingOnlyFromAGivenSetTest {
         assertEquals(
             defaultPropertyTrialCount(),
             PrimitiveBooleans.iterations);
+        PrimitiveBooleans.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -77,6 +78,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void wrapperBooleans() throws Exception {
         assertThat(testResult(WrapperBooleans.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), WrapperBooleans.iterations);
+        WrapperBooleans.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -94,6 +96,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void primitiveBytes() throws Exception {
         assertThat(testResult(PrimitiveBytes.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), PrimitiveBytes.iterations);
+        PrimitiveBytes.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -112,6 +115,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void wrapperBytes() throws Exception {
         assertThat(testResult(WrapperBytes.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), WrapperBytes.iterations);
+        WrapperBytes.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -130,6 +134,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void primitiveChars() throws Exception {
         assertThat(testResult(PrimitiveChars.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), PrimitiveChars.iterations);
+        PrimitiveChars.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -148,6 +153,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void wrapperChars() throws Exception {
         assertThat(testResult(WrapperChars.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), WrapperChars.iterations);
+        WrapperChars.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -166,6 +172,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void primitiveDoubles() throws Exception {
         assertThat(testResult(PrimitiveDoubles.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), PrimitiveDoubles.iterations);
+        PrimitiveDoubles.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -184,6 +191,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void wrapperDoubles() throws Exception {
         assertThat(testResult(WrapperDoubles.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), WrapperDoubles.iterations);
+        WrapperDoubles.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -202,6 +210,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void primitiveFloats() throws Exception {
         assertThat(testResult(PrimitiveFloats.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), PrimitiveFloats.iterations);
+        PrimitiveFloats.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -220,6 +229,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void wrapperFloats() throws Exception {
         assertThat(testResult(WrapperFloats.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), WrapperFloats.iterations);
+        WrapperFloats.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -240,6 +250,7 @@ public class SamplingOnlyFromAGivenSetTest {
         assertEquals(
             defaultPropertyTrialCount(),
             PrimitiveIntegers.iterations);
+        PrimitiveIntegers.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -258,6 +269,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void wrapperIntegers() throws Exception {
         assertThat(testResult(WrapperIntegers.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), WrapperIntegers.iterations);
+        WrapperIntegers.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -276,6 +288,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void primitiveLongs() throws Exception {
         assertThat(testResult(PrimitiveLongs.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), PrimitiveLongs.iterations);
+        PrimitiveLongs.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -294,6 +307,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void wrapperLongs() throws Exception {
         assertThat(testResult(WrapperLongs.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), WrapperLongs.iterations);
+        WrapperLongs.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -312,6 +326,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void primitiveShorts() throws Exception {
         assertThat(testResult(PrimitiveShorts.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), PrimitiveShorts.iterations);
+        PrimitiveShorts.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -330,6 +345,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void wrapperShorts() throws Exception {
         assertThat(testResult(WrapperShorts.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), WrapperShorts.iterations);
+        WrapperShorts.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -348,6 +364,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void strings() throws Exception {
         assertThat(testResult(Strings.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), Strings.iterations);
+        Strings.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -366,6 +383,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void enums() throws Exception {
         assertThat(testResult(Enums.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), Enums.iterations);
+        Enums.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -386,6 +404,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void ctorOnly() throws Exception {
         assertThat(testResult(CtorOnly.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), CtorOnly.iterations);
+        CtorOnly.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -421,6 +440,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void favorValueOf() throws Exception {
         assertThat(testResult(FavorValueOf.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), FavorValueOf.iterations);
+        FavorValueOf.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -468,6 +488,7 @@ public class SamplingOnlyFromAGivenSetTest {
             testResult(NoImplicitConversion.class),
             hasSingleFailureContaining(ReflectionException.class.getName()));
         assertEquals(0, NoImplicitConversion.iterations);
+        NoImplicitConversion.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -487,6 +508,7 @@ public class SamplingOnlyFromAGivenSetTest {
         assertEquals(
             defaultPropertyTrialCount(),
             ExplicitConversion.iterations);
+        ExplicitConversion.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -519,6 +541,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void manyParameters() throws Exception {
         assertThat(testResult(ManyParameters.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), ManyParameters.iterations);
+        ManyParameters.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -543,6 +566,7 @@ public class SamplingOnlyFromAGivenSetTest {
     @Test public void onlyTrumpsAlso() throws Exception {
         assertThat(testResult(OnlyTrumpsAlso.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), OnlyTrumpsAlso.iterations);
+        OnlyTrumpsAlso.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -565,6 +589,7 @@ public class SamplingOnlyFromAGivenSetTest {
         assertEquals(
             defaultPropertyTrialCount(),
             OnlyTrumpsGenerators.iterations);
+        OnlyTrumpsGenerators.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/ShrinkingTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/ShrinkingTest.java
@@ -101,6 +101,7 @@ public class ShrinkingTest {
         assertThat(
             testResult(FailedAssumptionDuringShrinking.class),
             hasSingleFailureContaining("With arguments: ["));
+        FailedAssumptionDuringShrinking.shrinking = false;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -120,6 +121,7 @@ public class ShrinkingTest {
     @Test public void disablingShrinking() {
         assertThat(testResult(DisablingShrinking.class), failureCountIs(1));
         assertEquals(1, DisablingShrinking.attempts.size());
+        DisablingShrinking.attempts.clear();
     }
 
     @RunWith(JUnitQuickcheck.class)


### PR DESCRIPTION
This PR is similar to #357 and this PR fixes all remaining cases of pollution that I know of.

1. Failed Tests:
- This PR fixes flaky tests in 9 classes:
```
com.pholser.junit.quickcheck.ComponentizedGeneratorsIsolateConfigurationFromComponentsTest
com.pholser.junit.quickcheck.EnumPropertyParameterTypesTest
com.pholser.junit.quickcheck.ExhaustingAGivenSetButIncludingAnotherTest
com.pholser.junit.quickcheck.ExhaustingAGivenSetTest
com.pholser.junit.quickcheck.LambdaPropertyParameterTypesTest
com.pholser.junit.quickcheck.PropertyExhaustiveSampleSizeTest
com.pholser.junit.quickcheck.SamplingButAlsoIncludingAGivenSetTest
com.pholser.junit.quickcheck.SamplingOnlyFromAGivenSetTest
com.pholser.junit.quickcheck.ShrinkingTest
```
2. Why they fail
- These tests pollute the state shared among tests without clearing
   1) `xxx.iterations`, 
   2) boolen variable (`FailedAssumptionDuringShrinking.shrinking`),
   3) arraylist (e.g., `DisablingShrinking.attempts`) or,
   4) list (e.g., `ManyParameters.firstTestCases`).
- It may be better to clean state pollution so that some other tests won't fail in the future due to the shared state polluted by these tests.
3. Reproduce test failures
- Rerun the tests twice in the same JVM.
- We can get failures, e.g., `com.pholser.junit.quickcheck.ShrinkingTest.disablingShrinking:125 expected:<1> but was:<2>`
4. Fix them
- Reset the appropriate shared state at the end of each test.